### PR TITLE
Add placeholder handling for missing product images

### DIFF
--- a/src/components/GiftProducts.tsx
+++ b/src/components/GiftProducts.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Gift, Heart, Star, ShoppingCart, Eye, Package, Sparkles } from 'lucide-react';
 import { useCart } from '../contexts/CartContext';
+import { resolveProductImage } from '../utils/productImages';
 
 interface GiftProduct {
   id: string;
@@ -166,6 +167,8 @@ export const GiftProducts: React.FC = () => {
   };
 
   if (selectedProduct) {
+    const { src, placeholder } = resolveProductImage(selectedProduct);
+
     return (
       <div className="max-w-7xl mx-auto">
         {/* Product Detail View */}
@@ -183,9 +186,14 @@ export const GiftProducts: React.FC = () => {
           <div className="space-y-4">
             <div className="bg-white rounded-2xl shadow-lg overflow-hidden">
               <img
-                src={selectedProduct.image}
+                src={src}
                 alt={selectedProduct.name}
                 className="w-full h-96 object-cover"
+                onError={(event) => {
+                  if (event.currentTarget.src !== placeholder) {
+                    event.currentTarget.src = placeholder;
+                  }
+                }}
               />
             </div>
             
@@ -362,45 +370,53 @@ export const GiftProducts: React.FC = () => {
 
       {/* Products Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-        {filteredAndSortedProducts.map(product => (
-          <div
-            key={product.id}
-            className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 group"
-          >
-            <div className="relative h-48 overflow-hidden">
-              <img
-                src={product.image}
-                alt={product.name}
-                className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110 cursor-pointer"
-                onClick={() => setSelectedProduct(product)}
-              />
-              
-              {/* Badges */}
-              <div className="absolute top-3 left-3 flex flex-col space-y-2">
-                {product.popular && (
-                  <div className="bg-red-500 text-white px-3 py-1 rounded-full text-xs font-medium flex items-center space-x-1">
-                    <Heart className="h-3 w-3" />
-                    <span>Popular</span>
-                  </div>
-                )}
-                {product.originalPrice && (
-                  <div className="bg-green-500 text-white px-3 py-1 rounded-full text-xs font-medium">
-                    {Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100)}% OFF
-                  </div>
-                )}
-              </div>
+        {filteredAndSortedProducts.map(product => {
+          const { src, placeholder } = resolveProductImage(product);
 
-              {/* Quick View Button */}
-              <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
-                <button
+          return (
+            <div
+              key={product.id}
+              className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 group"
+            >
+              <div className="relative h-48 overflow-hidden">
+                <img
+                  src={src}
+                  alt={product.name}
+                  className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110 cursor-pointer"
                   onClick={() => setSelectedProduct(product)}
-                  className="bg-white text-gray-800 px-4 py-2 rounded-lg font-medium hover:bg-gray-100 transition-colors flex items-center space-x-2"
-                >
-                  <Eye className="h-4 w-4" />
-                  <span>Quick View</span>
-                </button>
+                  onError={(event) => {
+                    if (event.currentTarget.src !== placeholder) {
+                      event.currentTarget.src = placeholder;
+                    }
+                  }}
+                />
+
+                {/* Badges */}
+                <div className="absolute top-3 left-3 flex flex-col space-y-2">
+                  {product.popular && (
+                    <div className="bg-red-500 text-white px-3 py-1 rounded-full text-xs font-medium flex items-center space-x-1">
+                      <Heart className="h-3 w-3" />
+                      <span>Popular</span>
+                    </div>
+                  )}
+                  {product.originalPrice && (
+                    <div className="bg-green-500 text-white px-3 py-1 rounded-full text-xs font-medium">
+                      {Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100)}% OFF
+                    </div>
+                  )}
+                </div>
+
+                {/* Quick View Button */}
+                <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
+                  <button
+                    onClick={() => setSelectedProduct(product)}
+                    className="bg-white text-gray-800 px-4 py-2 rounded-lg font-medium hover:bg-gray-100 transition-colors flex items-center space-x-2"
+                  >
+                    <Eye className="h-4 w-4" />
+                    <span>Quick View</span>
+                  </button>
+                </div>
               </div>
-            </div>
             
             <div className="p-6">
               <div className="flex items-center justify-between mb-2">
@@ -433,8 +449,9 @@ export const GiftProducts: React.FC = () => {
                 <span>Add to Cart</span>
               </button>
             </div>
-          </div>
-        ))}
+            </div>
+          );
+        })}
       </div>
 
       {/* Gift Services */}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Ruler, Eye } from 'lucide-react';
 import { Product } from './ProductCatalog';
+import { resolveProductImage } from '../utils/productImages';
 
 interface ProductCardProps {
   product: Product;
@@ -8,13 +9,20 @@ interface ProductCardProps {
 }
 
 export const ProductCard: React.FC<ProductCardProps> = ({ product, onProductClick }) => {
+  const { src, placeholder } = resolveProductImage(product);
+
   return (
     <div className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1">
       <div className="relative h-48 overflow-hidden">
         <img
-          src={product.image}
+          src={src}
           alt={product.name}
           className="w-full h-full object-cover transition-transform duration-300 hover:scale-105 cursor-pointer"
+          onError={(event) => {
+            if (event.currentTarget.src !== placeholder) {
+              event.currentTarget.src = placeholder;
+            }
+          }}
           onClick={() => onProductClick(product)}
         />
         <div className="absolute top-4 right-4 bg-blue-600 text-white px-3 py-1 rounded-full text-sm font-medium">

--- a/src/components/ProductCatalog.tsx
+++ b/src/components/ProductCatalog.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { ProductCard } from './ProductCard';
 import { Search, Filter } from 'lucide-react';
 import { apiService } from '../services/api';
+import { resolveProductImage } from '../utils/productImages';
 
 export interface Product {
   id: string;
@@ -10,7 +11,7 @@ export interface Product {
   category: string;
   description: string;
   basePrice: number;
-  image: string;
+  image?: string | null;
   specifications?: string[];
 }
 
@@ -31,7 +32,21 @@ export const ProductCatalog: React.FC<ProductCatalogProps> = ({ onProductClick }
       try {
         setLoading(true);
         const response = await apiService.getProducts();
-        setProducts(response.products || []);
+        const normalizedProducts = (response.products || []).map((product: Product) => {
+          const { src } = resolveProductImage({
+            image: product.image,
+            name: product.name,
+            description: product.description,
+            category: product.category,
+          });
+
+          return {
+            ...product,
+            image: src,
+          };
+        });
+
+        setProducts(normalizedProducts);
         setError(null);
       } catch (err) {
         console.error('Failed to fetch products:', err);
@@ -65,7 +80,13 @@ export const ProductCatalog: React.FC<ProductCatalogProps> = ({ onProductClick }
             image: 'https://images.pexels.com/photos/1571453/pexels-photo-1571453.jpeg?auto=compress&cs=tinysrgb&w=400&h=300&fit=crop',
             specifications: ['8mm thickness', 'Safety certified', 'Heat resistant', 'Shatterproof']
           }
-        ]);
+        ].map(product => {
+          const { src } = resolveProductImage(product);
+          return {
+            ...product,
+            image: src,
+          };
+        }));
       } finally {
         setLoading(false);
       }

--- a/src/components/ProductCustomizer.tsx
+++ b/src/components/ProductCustomizer.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { X, Calculator, ShoppingCart } from 'lucide-react';
 import { Product } from './ProductCatalog';
 import { useCart } from '../contexts/CartContext';
+import { resolveProductImage } from '../utils/productImages';
 
 interface ProductCustomizerProps {
   product: Product;
@@ -13,6 +14,7 @@ export const ProductCustomizer: React.FC<ProductCustomizerProps> = ({ product, o
   const [width, setWidth] = useState(36);
   const [quantity, setQuantity] = useState(1);
   const { addToCart } = useCart();
+  const { src, placeholder } = resolveProductImage(product);
 
   const area = (height * width) / 144; // Convert to square feet
   const totalPrice = area * product.basePrice * quantity;
@@ -52,9 +54,14 @@ export const ProductCustomizer: React.FC<ProductCustomizerProps> = ({ product, o
           <div className="grid md:grid-cols-2 gap-6">
             <div>
               <img
-                src={product.image}
+                src={src}
                 alt={product.name}
                 className="w-full h-48 object-cover rounded-lg"
+                onError={(event) => {
+                  if (event.currentTarget.src !== placeholder) {
+                    event.currentTarget.src = placeholder;
+                  }
+                }}
               />
             </div>
             

--- a/src/components/ProductDetails.tsx
+++ b/src/components/ProductDetails.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { ArrowLeft, Calculator, ShoppingCart, Star, Shield, Truck, Award } from 'lucide-react';
 import { Product } from './ProductCatalog';
 import { useCart } from '../contexts/CartContext';
+import { resolveProductImage } from '../utils/productImages';
 
 interface ProductDetailsProps {
   product: Product;
@@ -13,6 +14,7 @@ export const ProductDetails: React.FC<ProductDetailsProps> = ({ product, onBack 
   const [width, setWidth] = useState(36);
   const [quantity, setQuantity] = useState(1);
   const { addToCart } = useCart();
+  const { src, placeholder } = resolveProductImage(product);
 
   const area = (height * width) / 144; // Convert to square feet
   const totalPrice = area * product.basePrice * quantity;
@@ -53,9 +55,14 @@ export const ProductDetails: React.FC<ProductDetailsProps> = ({ product, onBack 
         <div className="space-y-4">
           <div className="bg-white rounded-2xl shadow-lg overflow-hidden">
             <img
-              src={product.image}
+              src={src}
               alt={product.name}
               className="w-full h-96 object-cover"
+              onError={(event) => {
+                if (event.currentTarget.src !== placeholder) {
+                  event.currentTarget.src = placeholder;
+                }
+              }}
             />
           </div>
           

--- a/src/utils/productImages.ts
+++ b/src/utils/productImages.ts
@@ -1,0 +1,75 @@
+const INVALID_IMAGE_VALUES = new Set(['', '#', 'n/a', 'na', 'null', 'undefined']);
+
+function sanitizeImageUrl(imageUrl?: string | null): string | null {
+  if (!imageUrl) {
+    return null;
+  }
+
+  const trimmed = imageUrl.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (INVALID_IMAGE_VALUES.has(trimmed.toLowerCase())) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+function buildKeywordString({
+  name,
+  description,
+  category,
+}: {
+  name: string;
+  description?: string;
+  category?: string;
+}): string {
+  const rawKeywords = [category, name, description]
+    .filter(Boolean)
+    .join(' ')
+    .replace(/[\n\r]+/g, ' ')
+    .replace(/[^a-zA-Z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 6)
+    .map(keyword => keyword.toLowerCase());
+
+  const uniqueKeywords = Array.from(new Set(['glass', ...rawKeywords]));
+
+  return uniqueKeywords.join(',');
+}
+
+export function generateProductPlaceholderImage({
+  name,
+  description,
+  category,
+}: {
+  name: string;
+  description?: string;
+  category?: string;
+}): string {
+  const keywords = buildKeywordString({ name, description, category });
+  return `https://source.unsplash.com/400x300/?${encodeURIComponent(keywords)}`;
+}
+
+export function resolveProductImage({
+  image,
+  name,
+  description,
+  category,
+}: {
+  image?: string | null;
+  name: string;
+  description?: string;
+  category?: string;
+}): { src: string; placeholder: string } {
+  const placeholder = generateProductPlaceholderImage({ name, description, category });
+  const sanitized = sanitizeImageUrl(image);
+
+  return {
+    src: sanitized ?? placeholder,
+    placeholder,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared utility to sanitize product image URLs and derive placeholder imagery from product metadata
- normalize catalog data and front-end components to rely on the new utility so broken or missing images display contextual fallbacks
- extend gift product listings and detail views with the same error handling to keep imagery consistent across the storefront

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68cc15bef2d0832f88bed80b9e56bf18