### PR TITLE
Rename gifts tab to gift products

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -66,7 +66,7 @@ export const Header: React.FC<HeaderProps> = ({
               }`}
             >
               <Gift className="h-5 w-5" />
-              <span className="font-medium">Gifts</span>
+              <span className="font-medium">Gift Products</span>
             </button>
             
             <button


### PR DESCRIPTION
## Summary
- update the header navigation label from "Gifts" to "Gift Products" to better reflect the section content

## Testing
- npm run lint (fails: existing lint errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68d0050f54dc832f8edfa38663a000cf