### PR TITLE
Remove personalized category filter from gift products

### DIFF
--- a/src/components/GiftProducts.tsx
+++ b/src/components/GiftProducts.tsx
@@ -125,7 +125,12 @@ export const GiftProducts: React.FC = () => {
   const [selectedProduct, setSelectedProduct] = useState<GiftProduct | null>(null);
   const { addToCart } = useCart();
 
-  const categories = ['All', ...Array.from(new Set(giftProducts.map(p => p.category)))];
+  const categories = [
+    'All',
+    ...Array.from(new Set(giftProducts.map(p => p.category))).filter(
+      category => category !== 'Personalized'
+    )
+  ];
 
   const filteredAndSortedProducts = giftProducts
     .filter(product => selectedCategory === 'All' || product.category === selectedCategory)


### PR DESCRIPTION
## Summary
- update the gift products category list to exclude the Personalized option from the filter buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00715b89c832f8bb6c163d5a8d589